### PR TITLE
Add snooze command for rescheduling tasks

### DIFF
--- a/src/main/java/rat/Deadline.java
+++ b/src/main/java/rat/Deadline.java
@@ -35,6 +35,26 @@ public class Deadline extends Task {
     }
 
     /**
+     * Updates the stored due date using the same parsing rules as construction.
+     *
+     * @param newBy textual representation of the new due date/time
+     */
+    public void reschedule(String newBy) {
+        assert newBy != null : "Deadline reschedule requires non-null input";
+        this.by = parseDateTime(newBy);
+    }
+
+    /**
+     * Updates the stored due date with a concrete timestamp.
+     *
+     * @param newBy new due moment
+     */
+    public void reschedule(LocalDateTime newBy) {
+        assert newBy != null : "Deadline reschedule requires a non-null timestamp";
+        this.by = newBy;
+    }
+
+    /**
      * Parses a date/time string into LocalDateTime.
      * Supports formats: yyyy-MM-dd, yyyy-MM-dd HHmm, dd/MM/yyyy HHmm, yyyy-MM-ddTHH:mm
      * @param dateTimeStr the date/time string to parse

--- a/src/main/java/rat/Event.java
+++ b/src/main/java/rat/Event.java
@@ -41,6 +41,32 @@ public class Event extends Task{
     }
 
     /**
+     * Reschedules this event using textual date/time values.
+     *
+     * @param newFrom textual new start time
+     * @param newTo textual new end time
+     */
+    public void reschedule(String newFrom, String newTo) {
+        assert newFrom != null : "Event reschedule requires non-null start";
+        assert newTo != null : "Event reschedule requires non-null end";
+        this.from = parseDateTime(newFrom);
+        this.to = parseDateTime(newTo);
+    }
+
+    /**
+     * Reschedules this event using explicit timestamps.
+     *
+     * @param newFrom new start time
+     * @param newTo new end time
+     */
+    public void reschedule(LocalDateTime newFrom, LocalDateTime newTo) {
+        assert newFrom != null : "Event reschedule requires a start timestamp";
+        assert newTo != null : "Event reschedule requires an end timestamp";
+        this.from = newFrom;
+        this.to = newTo;
+    }
+
+    /**
      * Parses a date/time string into LocalDateTime.
      * Supports formats: yyyy-MM-dd, yyyy-MM-dd HHmm, dd/MM/yyyy HHmm, yyyy-MM-ddTHH:mm
      * @param dateTimeStr the date/time string to parse

--- a/src/main/java/rat/Parser.java
+++ b/src/main/java/rat/Parser.java
@@ -10,6 +10,7 @@ import rat.command.EventCommand;
 import rat.command.FindCommand;
 import rat.command.ListCommand;
 import rat.command.MarkCommand;
+import rat.command.SnoozeCommand;
 import rat.command.TodoCommand;
 import rat.command.UnmarkCommand;
 
@@ -28,33 +29,16 @@ public class Parser {
     public static Command parse(String input) throws RatException {
         assert input != null : "Parser.parse expects non-null input";
         String trimmed = input.trim();
-        if (trimmed.equalsIgnoreCase("bye")) {
-            return new ByeCommand();
-        }
-        if (trimmed.equalsIgnoreCase("list")) {
-            return new ListCommand();
-        }
-        if (trimmed.startsWith("mark")) {
-            return parseMarkCommand(trimmed);
-        }
-        if (trimmed.startsWith("unmark")) {
-            return parseUnmarkCommand(trimmed);
-        }
-        if (trimmed.startsWith("todo")) {
-            return new TodoCommand(trimmed.substring(4).trim());
-        }
-        if (trimmed.startsWith("deadline")) {
-            return parseDeadlineCommand(trimmed);
-        }
-        if (trimmed.startsWith("event")) {
-            return parseEventCommand(trimmed);
-        }
-        if (trimmed.startsWith("delete")) {
-            return parseDeleteCommand(trimmed);
-        }
-        if (trimmed.startsWith("find")) {
-            return parseFindCommand(trimmed);
-        }
+        if (trimmed.equalsIgnoreCase("bye")) return new ByeCommand();
+        if (trimmed.equalsIgnoreCase("list")) return new ListCommand();
+        if (trimmed.startsWith("mark")) return parseMarkCommand(trimmed);
+        if (trimmed.startsWith("unmark")) return parseUnmarkCommand(trimmed);
+        if (trimmed.startsWith("todo")) return new TodoCommand(trimmed.substring(4).trim());
+        if (trimmed.startsWith("deadline")) return parseDeadlineCommand(trimmed);
+        if (trimmed.startsWith("event")) return parseEventCommand(trimmed);
+        if (trimmed.startsWith("delete")) return parseDeleteCommand(trimmed);
+        if (trimmed.startsWith("find")) return parseFindCommand(trimmed);
+        if (trimmed.startsWith("snooze")) return parseSnoozeCommand(trimmed);
         throw new RatException("I don't understand that command.");
     }
 
@@ -130,5 +114,55 @@ public class Parser {
             throw new RatException("Please provide a keyword to search for. Usage: find keyword");
         }
         return FindCommand.byKeyword(args);
+    }
+
+    private static Command parseSnoozeCommand(String trimmed) throws RatException {
+        String body = trimmed.substring(6).trim();
+        if (body.isEmpty()) {
+            throw new RatException("Please provide a task number to snooze.");
+        }
+        String[] split = body.split(" ", 2);
+        String indexToken = split[0];
+        assert !indexToken.isBlank() : "Snooze command requires an index token";
+        int index = Integer.parseInt(indexToken) - 1;
+        String options = split.length > 1 ? split[1].trim() : "";
+        if (options.isEmpty()) {
+            throw new RatException("Please provide new schedule details using /by or /from and /to.");
+        }
+
+        String newBy = null;
+        String newFrom = null;
+        String newTo = null;
+
+        if (options.startsWith("/by") || options.contains("/by")) {
+            String[] bySplit = options.split("/by", 2);
+            if (bySplit.length < 2) {
+                throw new RatException("Please provide the new date/time after /by.");
+            }
+            newBy = bySplit[1].trim();
+            if (newBy.isEmpty()) {
+                throw new RatException("Please provide the new date/time after /by.");
+            }
+        } else {
+            if (!options.contains("/from")) {
+                throw new RatException("Events should specify /from and /to when snoozing.");
+            }
+            String[] fromSplit = options.split("/from", 2);
+            if (fromSplit.length < 2) {
+                throw new RatException("Please provide the new start time after /from.");
+            }
+            String rest = fromSplit[1];
+            String[] toSplit = rest.split("/to", 2);
+            if (toSplit.length < 2) {
+                throw new RatException("Please provide the new end time after /to.");
+            }
+            newFrom = toSplit[0].trim();
+            newTo = toSplit[1].trim();
+            if (newFrom.isEmpty() || newTo.isEmpty()) {
+                throw new RatException("Please provide both start and end times when snoozing an event.");
+            }
+        }
+
+        return new SnoozeCommand(index, newBy, newFrom, newTo);
     }
 }

--- a/src/main/java/rat/command/SnoozeCommand.java
+++ b/src/main/java/rat/command/SnoozeCommand.java
@@ -1,0 +1,61 @@
+package rat.command;
+
+import rat.Deadline;
+import rat.Event;
+import rat.RatException;
+import rat.Storage;
+import rat.Task;
+import rat.TaskList;
+import rat.Ui;
+
+/**
+ * Command that reschedules deadline or event tasks to a new time.
+ */
+public class SnoozeCommand extends Command {
+    private final int index;
+    private final String newBy; // nullable, used for deadlines
+    private final String newFrom; // nullable, used for events
+    private final String newTo; // nullable, used for events
+
+    public SnoozeCommand(int index, String newBy, String newFrom, String newTo) {
+        this.index = index;
+        this.newBy = newBy;
+        this.newFrom = newFrom;
+        this.newTo = newTo;
+    }
+
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) throws RatException {
+        assert tasks != null : "SnoozeCommand expects a TaskList";
+        assert ui != null : "SnoozeCommand expects a Ui";
+        assert storage != null : "SnoozeCommand expects storage";
+        if (index < 0 || index >= tasks.size()) {
+            throw new RatException("That task number does not exist.");
+        }
+
+        Task task = tasks.get(index);
+        if (task instanceof Deadline) {
+            if (newBy == null || newBy.isBlank()) {
+                throw new RatException("Please specify the new deadline using /by.");
+            }
+            Deadline deadline = (Deadline) task;
+            deadline.reschedule(newBy);
+        } else if (task instanceof Event) {
+            if (newFrom == null || newFrom.isBlank() || newTo == null || newTo.isBlank()) {
+                throw new RatException("Please specify both /from and /to for events when snoozing.");
+            }
+            Event event = (Event) task;
+            event.reschedule(newFrom, newTo);
+        } else {
+            throw new RatException("Only deadlines and events can be snoozed.");
+        }
+
+        try {
+            storage.save(tasks.asList());
+        } catch (java.io.IOException e) {
+            // Persisting failure should not crash the app; surface via UI instead.
+        }
+
+        return " Got it. I've rescheduled this task:\n   " + task;
+    }
+}


### PR DESCRIPTION
Deadlines and events cannot be updated once created, forcing users to delete and recreate them when timings change.

Let's add a SnoozeCommand with helpers in Deadline and Event to support rescheduling, and update the Parser to recognize the new command. This improves flexibility without complicating parsing logic.